### PR TITLE
Remove deprecated go generate usage from example

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,4 @@
 | Denis Cheremisov | [github.com/sirkon](https://github.com/sirkon)     | Owner                 |
 | Tim De Waal      | [github.com/Caesurus](https://github.com/Caesurus) | Bug reports and fixes |
 | Matt Hook        | [github.com/hookenz](https://github.com/hookenz)   | Bug reports and proposals |
+| Casey Strouse    | [github.com/cstrouse](https://github.com/cstrouse) | Bug reports and fixes |

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Line =                                   # Name of the extraction object' type
 ```
 
 ##### Code generation
-The recommended way is to put something like `//go:generate ldetool generate --package main Line.lde` in `generate.go` of a package and then generate a code with
+The recommended way is to put something like `//go:generate ldetool --package main Line.lde` in `generate.go` of a package and then generate a code with
 ```bash
 go generate <project path>
 ```


### PR DESCRIPTION
Use of the generate subcommand has been deprecated. This updates the
example showing the recommended way to include the code generation in
your package to reflect that.